### PR TITLE
Replace PersistentVolumeClaim with volumeClaimTemplate

### DIFF
--- a/deployment/mongo-db.yaml
+++ b/deployment/mongo-db.yaml
@@ -1,18 +1,3 @@
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: mongodb-pvc
-  namespace: livius
-  labels:
-    app: livius
-    tier: mongodb
-spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 10Gi
----
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -47,7 +32,15 @@ spec:
       volumes:
         - name: mongodb-data
           persistentVolumeClaim:
-            claimName: mongodb-pvc
+            claimName: mongodb-pvc-template
+  volumeClaimTemplates:
+    - metadata:
+        name: mongodb-data
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        resources:
+          requests:
+            storage: 10Gi
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
The existing PersistentVolumeClaim in the mongo-db.yaml file has been replaced with volumeClaimTemplates to provide dynamic provisioning of storage. Now, each replica of the stateful set will have its own unique PersistentVolume and PersistentVolumeClaim, ensuring more efficient storage handling.