### PR TITLE
Update boolean values to string in backend-data.yaml

### DIFF
--- a/deployment/backend-data.yaml
+++ b/deployment/backend-data.yaml
@@ -33,9 +33,9 @@ spec:
             - name: LIVIUS_DB
               value: test
             - name: LIVIUS_APP_COW_START_JOBS
-              value: true
+              value: 'true'
             - name: LIVIUS_APP_WEATHER_START_JOBS
-              value: true
+              value: 'true'
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
In the backend-data.yaml, boolean values 'true' for LIVIUS_APP_COW_START_JOBS and LIVIUS_APP_WEATHER_START_JOBS have been updated to string 'true'. This is to match the expected data type in the environment configurations.